### PR TITLE
Exclude #'clojure.core/update to avoid a refer warning

### DIFF
--- a/src/kormas/sql.clj
+++ b/src/kormas/sql.clj
@@ -1,4 +1,5 @@
 (ns kormas.sql
+  (:refer-clojure :exclude [update])
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
             (korma [core :refer :all]


### PR DESCRIPTION
This PR fixes the following warning occurred when kormas is used with Clojure v1.7.0.

```
WARNING: update already refers to: #'clojure.core/update in namespace: kormas.sql, being replaced by: #'korma.core/update
```
